### PR TITLE
Fix docker host mapping for Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ bash scripts/run_analysis.sh
 ```
 
 The Windows PowerShell script has been removed; use the shell script on Linux.
+
+## Troubleshooting Database Connection Errors
+
+If the web service logs show `ECONNREFUSED` when connecting to PostgreSQL,
+check the following:
+
+1. Ensure your PostgreSQL server listens on an address accessible from the
+   Docker container. In `postgresql.conf` set
+   `listen_addresses = '*'` (or include your host's IP) and restart the service.
+2. On Linux, Docker does not automatically provide the `host.docker.internal`
+   hostname. The `docker-compose.yml` file maps this name to the host using
+   `extra_hosts`. Rebuild the container after updating Compose if needed.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,13 @@ services:
       - NODE_ENV=production
       # PostgreSQL connection strings
       - TRADES_DB_URL=postgresql://trader:xyz@host.docker.internal:5432/trades
-      
+
       - MARKET_DB_URL=postgresql://marketmaker:xyz@host.docker.internal:5432/market
+    # Map host.docker.internal to the Docker host on Linux
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
-      retries: 3 
+      retries: 3


### PR DESCRIPTION
## Summary
- map `host.docker.internal` to the host on Linux
- document how to resolve `ECONNREFUSED` database errors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d74ae0d38832d80ef25577683a3bf