### PR TITLE
Add market configuration settings

### DIFF
--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+import { getMarketTables } from "@/lib/db"
+
+export async function GET() {
+  try {
+    const tables = await getMarketTables()
+    return NextResponse.json({ success: true, tables })
+  } catch (error) {
+    console.error("API: failed to fetch market tables", error)
+    return NextResponse.json({ success: false, tables: [] })
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -93,6 +93,21 @@ const marketSql = async (strings: TemplateStringsArray, ...values: any[]) => {
   }
 };
 
+export async function getMarketTables(): Promise<string[]> {
+  try {
+    const result = await marketSql`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+    `;
+    return result.rows.map((r) => r.table_name as string);
+  } catch (error) {
+    console.error('Failed to fetch market tables:', error);
+    return [];
+  }
+}
+
 // Export pool and sql for external use
 export { pool, sql, marketPool, marketSql };
 


### PR DESCRIPTION
## Summary
- add API route to list available market tables
- add market nickname & type settings tab
- refresh sidebar assets based on configured markets
- move market nickname settings to the Storage tab as an inline table
- fix duplicate export in the DB helper

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685d7f9dc724832da01bd0f880eea6ee